### PR TITLE
Add basic HTTP metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Thanks to Chimera, users can skip registration of their own OAuth2 applications 
 Current support for Chimera in Mattermost plugins.
 
 | Plugin | Chimera Support Status |
-|--------|--------|-------|
+|--------|---------------|
 | [GitHub Plugin](https://github.com/mattermost/mattermost-plugin-github) | In Progress |
 | [GitLab Plugin](https://github.com/mattermost/mattermost-plugin-gitlab) | In Progress |
 | [Zoom Plugin](https://github.com/mattermost/mattermost-plugin-zoom) | In Progress |

--- a/cmd/chimera/options.go
+++ b/cmd/chimera/options.go
@@ -6,6 +6,7 @@ import (
 
 type ServerOptions struct {
 	Port                     int
+	MetricsPort              int `mapstructure:"metrics-port"`
 	Address                  string
 	AppsConfig               string `mapstructure:"apps-config"`
 	CacheDriver              string `mapstructure:"cache-driver"`

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	metricsNamespace = "chimera"
+
+	metricsSubsystemHTTP = "http"
+)
+
+// Collector is metrics collector.
+type Collector struct {
+	Registry *prometheus.Registry
+
+	httpResponseStatusCounters *prometheus.CounterVec
+	httpRequestDuration        *prometheus.HistogramVec
+
+	logger logrus.FieldLogger
+}
+
+// NewCollector creates new Collector and registers metrics.
+func NewCollector(logger logrus.FieldLogger) *Collector {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
+		Namespace: metricsNamespace,
+	}))
+
+	httpResponseStatusCounters := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystemHTTP,
+			Name:      "response_status",
+			Help:      "Status of HTTP response",
+		},
+		[]string{"status", "path", "method"},
+	)
+	registry.MustRegister(httpResponseStatusCounters)
+
+	httpRequestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystemHTTP,
+			Name:      "response_time_seconds",
+			Help:      "Duration of HTTP requests",
+		},
+		[]string{"path", "method"},
+	)
+	registry.MustRegister(httpRequestDuration)
+
+	return &Collector{
+		Registry:                   registry,
+		httpResponseStatusCounters: httpResponseStatusCounters,
+		httpRequestDuration:        httpRequestDuration,
+		logger:                     logger,
+	}
+}
+
+// MetricsHandler returns Prometheus HTTP metrics API handler.
+func (c *Collector) MetricsHandler() http.Handler {
+	router := mux.NewRouter()
+	router.Handle("/metrics", promhttp.InstrumentMetricHandler(c.Registry, promhttp.HandlerFor(c.Registry, promhttp.HandlerOpts{})))
+	return router
+}
+
+// MetricsMiddleware returns middleware used for collecting metrics.
+func (c *Collector) MetricsMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		method := r.Method
+
+		timer := prometheus.NewTimer(c.httpRequestDuration.WithLabelValues(path, method))
+
+		rw := newStatusWriter(w)
+		h.ServeHTTP(rw, r)
+
+		c.httpResponseStatusCounters.WithLabelValues(strconv.Itoa(rw.status), path, method).Inc()
+
+		timer.ObserveDuration()
+	})
+}
+
+// statusWriter preserves status written in the response so that it can be recorded.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func newStatusWriter(base http.ResponseWriter) *statusWriter {
+	return &statusWriter{
+		ResponseWriter: base,
+		status:         http.StatusOK,
+	}
+}
+
+// WriteHeader records status code and calls base ResponseWriter.
+func (r *statusWriter) WriteHeader(statusCode int) {
+	r.status = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR introduces the following changes:
- Add basic HTTP metrics:
  - Response status counter per endpoint and method.
  - Request duration histogram per endpoint and method.
- Add some unit tests checking if metrics are being collected.
- Move metrics server to a different port to not expose it externally.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-39069

